### PR TITLE
feat: add parser options and line-based parsing

### DIFF
--- a/aissembly_core/__init__.py
+++ b/aissembly_core/__init__.py
@@ -1,5 +1,5 @@
 """Core parser and executor for Aissembly minimal language."""
-from .parser import parse_program
+from .parser import parse_program, ParserOptions
 from .executor import Executor, load_llm_defs
 
-__all__ = ["parse_program", "Executor", "load_llm_defs"]
+__all__ = ["parse_program", "ParserOptions", "Executor", "load_llm_defs"]

--- a/tests/test_parser_options.py
+++ b/tests/test_parser_options.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from aissembly_core.parser import parse_program, ParserOptions
+
+PROGRAM = """
+let x = add(7, 6)
+let tag = cond(test=ge(x, 10)) -> \"ok\" ::else-> \"ng\"
+let total = for(range(1, 4), init=0) -> add(acc, i)
+let steps = while(test=lt(acc, 3), init=0) -> add(acc, 1)
+"""
+
+def test_parser_options_acceptance():
+    opts = ParserOptions(
+        accuracy_opt_passes=1,
+        decomposition_opt_passes=1,
+        integration_opt_passes=1,
+        loop_to_operation_opt_passes=1,
+        operation_to_loop_opt_passes=1,
+        condition_to_operation_opt_passes=1,
+    )
+    prog = parse_program(PROGRAM, options=opts)
+    assert len(prog.statements) == 4


### PR DESCRIPTION
## Summary
- allow parser to accept optimization pass counts via new `ParserOptions`
- reparse programs line-by-line and add hooks for six optimization phases
- expose `ParserOptions` in package API
- test parser accepts configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e25c7320832983cb9ca575f742ac