### PR TITLE
Add LLM adapter configuration and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ available in the `aissembly_core` package. Parse and run programs with:
 python -m aissembly_core.runtime path/to/program.asl --llm llm_functions.json
 ```
 
+LLM function specifications can define adapters for local scripts or HTTP APIs.
+See [docs/llm_adapters.md](docs/llm_adapters.md) for the configuration format.
+
 Unit tests demonstrate language features and can be executed via:
 
 ```bash

--- a/docs/llm_adapters.md
+++ b/docs/llm_adapters.md
@@ -1,0 +1,49 @@
+# LLM Adapters
+
+`llm_functions.json` entries can include an `adapter` field that describes how the
+runtime should route a call to a language model. Adapters allow Aissembly to
+connect to local scripts or remote HTTP services.
+
+## Python file adapter
+
+```json
+{
+  "name": "local_add",
+  "model": "local",
+  "adapter": {
+    "type": "python",
+    "path": "path/to/adapter.py",
+    "function": "add_adapter"
+  }
+}
+```
+
+The runtime loads the module at `path` and invokes the specified `function`
+with the positional and keyword arguments from the Aissembly program. This
+method can wrap Python, Julia, Go, or any language that exposes a Python
+callable.
+
+## HTTP adapter
+
+```json
+{
+  "name": "summarization",
+  "model": "gpt-4o-mini",
+  "adapter": {
+    "type": "http",
+    "url": "https://api.openai.com/v1/chat/completions",
+    "method": "POST",
+    "headers": {
+      "Authorization": "Bearer <token>"
+    }
+  }
+}
+```
+
+For HTTP adapters the runtime sends a JSON payload containing the function
+name, model and arguments. The JSON response body is returned as the result
+of the call. This mechanism can interface with providers such as Ollama,
+OpenAI, Claude or any custom service.
+
+If no `adapter` field is supplied, the executor returns a debug object
+containing the model name, function name and arguments.

--- a/llm_functions.json
+++ b/llm_functions.json
@@ -3,6 +3,11 @@
         "name": "summarization",
         "model": "gpt-4o-mini",
         "description": "Summarize the given text",
+        "adapter": {
+            "type": "http",
+            "url": "https://api.openai.com/v1/chat/completions",
+            "method": "POST"
+        },
         "parameters": {
             "type": "object",
             "properties": {

--- a/tests/test_llm_adapter.py
+++ b/tests/test_llm_adapter.py
@@ -1,0 +1,39 @@
+import json
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from aissembly_core.parser import parse_program
+from aissembly_core.executor import Executor, load_llm_defs
+
+
+def test_python_adapter(tmp_path):
+    adapter_file = tmp_path / "adapter.py"
+    adapter_file.write_text("""
+from typing import Any
+
+def add_adapter(a: Any, b: Any) -> Any:
+    return a + b
+""")
+
+    llm_json = tmp_path / "defs.json"
+    llm_json.write_text(json.dumps([
+        {
+            "name": "py_add",
+            "model": "local",
+            "adapter": {
+                "type": "python",
+                "path": str(adapter_file),
+                "function": "add_adapter"
+            },
+            "parameters": {"type": "object", "properties": {}}
+        }
+    ]))
+
+    llm_defs = load_llm_defs(str(llm_json))
+    program = parse_program("let result = py_add(1, 2)")
+    exe = Executor(llm_defs=llm_defs)
+    env = exe.run(program)
+    assert env["result"] == 3
+


### PR DESCRIPTION
## Summary
- allow LLM functions to specify adapters for Python files or HTTP APIs
- document adapter configuration and update example function
- add test covering Python adapter usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4e6e661f4832997b2cb84036aae99