### PR TITLE
Add rich Python-style primitives to Aissembly core

### DIFF
--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -1,0 +1,43 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from aissembly_core.parser import parse_program
+from aissembly_core.executor import Executor
+
+
+def run(src: str):
+    prog = parse_program(src)
+    exe = Executor()
+    return exe.run(prog)
+
+
+def test_primitives():
+    program = """
+let nums = 1 + 2 * 3
+let s = "he" + "llo"
+let sub = s[1:4]
+let lst = [1, 2]
+let lst2 = op.append(lst, 3)
+let first = lst2[0]
+let part = lst2[1:3]
+let d = {"x": 1}
+let d2 = op.set(d, "y", 2)
+let val = d2["y"]
+let hasx = op.has(d2, "x")
+let total = for(range(0, op.len(lst2)), init=0) -> acc + lst2[i]
+let tag = if(total == 6) ? "ok" : "ng"
+"""
+    env = run(program)
+    assert env["nums"] == 7
+    assert env["s"] == "hello"
+    assert env["sub"] == "ell"
+    assert env["lst2"] == [1, 2, 3]
+    assert env["first"] == 1
+    assert env["part"] == [2, 3]
+    assert env["d2"] == {"x": 1, "y": 2}
+    assert env["val"] == 2
+    assert env["hasx"] is True
+    assert env["total"] == 6
+    assert env["tag"] == "ok"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -7,10 +7,10 @@ from aissembly_core.parser import parse_program
 from aissembly_core.executor import Executor
 
 PROGRAM = """
-let x = add(7, 6)
-let tag = cond(test=ge(x, 10)) -> "ok" ::else-> "ng"
-let total = for(range(1, 4), init=0) -> add(acc, i)
-let steps = while(test=lt(acc, 3), init=0) -> add(acc, 1)
+let x = 7 + 6
+let tag = cond(test=x >= 10) -> "ok" ::else-> "ng"
+let total = for(range(1, 4), init=0) -> acc + i
+let steps = while(test=acc < 3, init=0) -> acc + 1
 """
 
 def test_execution():


### PR DESCRIPTION
## Summary
- expand parser to understand arithmetic, comparison, list/dict literals and indexing and map them to `op.*` calls
- extend executor with built-in operations for numbers, strings, lists and dictionaries
- add comprehensive tests covering numbers, strings, lists, dicts, loops and conditionals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4e81cc4c483299f6bd110bbe98329