### PR TITLE
feat: parameterize reparse iterations

### DIFF
--- a/aissembly_core/runtime.py
+++ b/aissembly_core/runtime.py
@@ -13,11 +13,21 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Run Aissembly program")
     parser.add_argument("program", help="Path to program file")
     parser.add_argument("--llm", dest="llm", help="Path to LLM definition JSON", default=None)
+    parser.add_argument(
+        "--reparse-iterations",
+        dest="reparse_iterations",
+        type=int,
+        default=1,
+        help="Number of line-by-line re-parsing iterations to run",
+    )
     args = parser.parse_args(argv)
 
     with open(args.program, "r", encoding="utf-8") as f:
         source = f.read()
-    prog = parse_program(source)
+
+    prog = None
+    for _ in range(max(args.reparse_iterations, 1)):
+        prog = parse_program(source)
 
     llm_defs: Dict[str, Dict] | None = None
     if args.llm:

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -6,10 +6,12 @@ Aissembly minimal language.
 ## Running Programs
 
 ```bash
-python -m aissembly_core.runtime path/to/program.asl --llm llm_functions.json
+python -m aissembly_core.runtime path/to/program.asl --llm llm_functions.json --reparse-iterations 2
 ```
 
-The optional `--llm` flag loads LLM function specifications in JSON format.
+The optional `--llm` flag loads LLM function specifications in JSON format.  The
+`--reparse-iterations` flag controls how many times the source is reparsed line
+by line before execution (default is `1`).
 
 ## Example
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3,8 +3,11 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
+import json
+
 from aissembly_core.parser import parse_program
 from aissembly_core.executor import Executor
+from aissembly_core import runtime
 
 PROGRAM = """
 let x = 7 + 6
@@ -17,6 +20,18 @@ def test_execution():
     prog = parse_program(PROGRAM)
     exe = Executor()
     env = exe.run(prog)
+    assert env["x"] == 13
+    assert env["tag"] == "ok"
+    assert env["total"] == 6
+    assert env["steps"] == 3
+
+
+def test_execution_with_reparse_iterations(tmp_path, capsys):
+    prog_path = tmp_path / "prog.asl"
+    prog_path.write_text(PROGRAM)
+    runtime.main([str(prog_path), "--reparse-iterations", "2"])
+    captured = capsys.readouterr().out
+    env = json.loads(captured)
     assert env["x"] == 13
     assert env["tag"] == "ok"
     assert env["total"] == 6


### PR DESCRIPTION
## Summary
- add CLI option to rerun line-by-line reparsing
- document `--reparse-iterations` usage in parser guide
- test runtime with custom reparse pass count

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a4fe3eeae883298ebd89d86c0a5e18