### PR TITLE
Add Ollama connect configuration example

### DIFF
--- a/docs/llm_adapters.md
+++ b/docs/llm_adapters.md
@@ -45,5 +45,41 @@ name, model and arguments. The JSON response body is returned as the result
 of the call. This mechanism can interface with providers such as Ollama,
 OpenAI, Claude or any custom service.
 
+## Ollama Connect example
+
+Ollama exposes a simple HTTP API. Start a local server with `ollama serve` or
+attach to a remote instance via `ollama connect <host>:11434`. The returned
+address becomes the base URL for the adapter.
+
+```bash
+ollama serve
+# or
+ollama connect myserver.example.com:11434
+```
+
+Configure `llm_functions.json` to point at the running service:
+
+```json
+{
+  "name": "ollama_chat",
+  "model": "llama3",
+  "adapter": {
+    "type": "http",
+    "url": "http://localhost:11434/api/generate",
+    "method": "POST"
+  },
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "prompt": {"type": "string", "description": "User prompt"}
+    },
+    "required": ["prompt"]
+  }
+}
+```
+
+The runtime will send requests to the specified URL using the HTTP adapter.
+Adjust the URL if `ollama connect` reports a different host or port.
+
 If no `adapter` field is supplied, the executor returns a debug object
 containing the model name, function name and arguments.

--- a/examples/ollama_chat.asl
+++ b/examples/ollama_chat.asl
@@ -1,0 +1,2 @@
+let response = ollama_chat("Say hello from Ollama.");
+print(response);

--- a/llm_functions.json
+++ b/llm_functions.json
@@ -16,5 +16,22 @@
             },
             "required": ["text"]
         }
+    },
+    {
+        "name": "ollama_chat",
+        "model": "llama3",
+        "description": "Send a prompt to a locally served Ollama model",
+        "adapter": {
+            "type": "http",
+            "url": "http://localhost:11434/api/generate",
+            "method": "POST"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string", "description": "User prompt"}
+            },
+            "required": ["prompt"]
+        }
     }
 ]

--- a/llm_functions.json.demo
+++ b/llm_functions.json.demo
@@ -16,5 +16,22 @@
             },
             "required": ["text"]
         }
+    },
+    {
+        "name": "ollama_chat",
+        "model": "llama3",
+        "description": "Send a prompt to a locally served Ollama model",
+        "adapter": {
+            "type": "http",
+            "url": "http://localhost:11434/api/generate",
+            "method": "POST"
+        },
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string", "description": "User prompt"}
+            },
+            "required": ["prompt"]
+        }
     }
 ]


### PR DESCRIPTION
## Summary
- document configuring `llm_functions.json` to use Ollama Connect
- add `ollama_chat` function entries in sample `llm_functions.json`
- include a simple `ollama_chat` program example

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a50f1b75d483299e8f9c140543beec