### PR TITLE
Support semicolon statement terminators in parser

### DIFF
--- a/aissembly_core/parser.py
+++ b/aissembly_core/parser.py
@@ -103,8 +103,8 @@ class TreeIndenter(Indenter):
 GRAMMAR = r"""
 start: (statement _NEWLINE*)*
 
-statement: "let" NAME "=" expr        -> let_stmt
-         | expr                       -> expr_stmt
+statement: "let" NAME "=" expr ";"?        -> let_stmt
+         | expr ";"?                       -> expr_stmt
 
 ?expr: cond_block
      | cond_inline
@@ -197,7 +197,8 @@ class ASTBuilder(Transformer):
         return Program(items)
 
     def let_stmt(self, items):
-        name, expr = items
+        name = items[0]
+        expr = items[1]
         return LetStmt(str(name), expr)
 
     def expr_stmt(self, items):

--- a/tests/test_semicolons.py
+++ b/tests/test_semicolons.py
@@ -1,0 +1,25 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from aissembly_core.parser import parse_program
+from aissembly_core.executor import Executor
+
+
+def run(src: str):
+    prog = parse_program(src)
+    exe = Executor()
+    return exe.run(prog)
+
+
+def test_basic_types_example_semicolons():
+    example_path = Path(os.path.dirname(os.path.dirname(__file__))) / "examples" / "basic_types.asl"
+    program = example_path.read_text()
+    env = run(program)
+    assert env["count"] == 42
+    assert env["ratio"] == 3.14
+    assert env["greeting"] == "hello"
+    assert env["items"] == [1, 2, 3]
+    assert env["config"] == {"mode": "dev", "limit": 5}


### PR DESCRIPTION
## Summary
- allow optional semicolons at the end of statements in the grammar
- handle optional semicolons in AST builder
- test parsing of example program with semicolon-terminated statements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a50f29c22c83299723c7cfc425f8fa