### PR TITLE
Fix cond_block example syntax

### DIFF
--- a/examples/cond_block.asl
+++ b/examples/cond_block.asl
@@ -1,8 +1,7 @@
-let x = 7 + 6;
-let tag = null;
+let x = 7 + 6
+let tag = cond(test=x >= 10):
+    then:
+        -> "ok"
+    else:
+        -> "ng"
 
-if (x >= 10) {
-  tag = "ok";
-} else {
-  tag = "ng";
-}


### PR DESCRIPTION
## Summary
- Replace invalid `if`/`else` block with `cond`-based conditional in `examples/cond_block.asl`
- Ensure example uses expression-based syntax supported by parser

## Testing
- `python -m aissembly_core.runtime examples/cond_block.asl --llm llm_functions.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a511ab52a083299689096734ebca48