### PR TITLE
Run examples in tests and expand builtins

### DIFF
--- a/aissembly_core/executor.py
+++ b/aissembly_core/executor.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, Iterable, List
 import json
 import importlib.util
 import urllib.request
+import math
 
 from .parser import (
     Program,
@@ -32,6 +33,43 @@ def _append(lst: List[Any], val: Any):
     return lst
 
 
+def _push(lst: List[Any], val: Any) -> int:
+    lst.append(val)
+    return len(lst)
+
+
+def _pop(lst: List[Any]):
+    return lst.pop()
+
+
+def _merge(a: Dict[Any, Any], b: Dict[Any, Any]) -> Dict[Any, Any]:
+    res = dict(a)
+    res.update(b)
+    return res
+
+
+def _split(s: str, sep: str) -> List[str]:
+    return s.split(sep)
+
+
+def _join(items: List[str], sep: str) -> str:
+    return sep.join(items)
+
+
+def _type(obj: Any) -> str:
+    return type(obj).__name__
+
+
+def _assert(cond: bool, msg: str = "Assertion failed") -> bool:
+    if not cond:
+        raise AssertionError(msg)
+    return True
+
+
+def _print(*args: Any) -> None:
+    print(*args)
+
+
 # Built-in operations
 BUILTINS = {
     "op.add": lambda a, b: a + b,
@@ -57,6 +95,29 @@ BUILTINS = {
     "op.slice": lambda obj, start, end: obj[start:end],
     "op.has": lambda d, key: key in d,
 }
+
+# Alias names used in examples
+BUILTINS.update(
+    {
+        "abs": abs,
+        "ceil": math.ceil,
+        "floor": math.floor,
+        "max": max,
+        "min": min,
+        "len": BUILTINS["op.len"],
+        "get": BUILTINS["op.get"],
+        "set": BUILTINS["op.set"],
+        "slice": BUILTINS["op.slice"],
+        "print": _print,
+        "pop": _pop,
+        "push": _push,
+        "split": _split,
+        "join": _join,
+        "merge": _merge,
+        "type": _type,
+        "assert": _assert,
+    }
+)
 
 
 class Executor:

--- a/aissembly_core/parser.py
+++ b/aissembly_core/parser.py
@@ -224,6 +224,8 @@ class ASTBuilder(Transformer):
         return ListLiteral(items)
 
     def dict_lit(self, items):
+        if items and items[0] is None:
+            items = []
         return DictLiteral(items)
 
     def pair(self, items):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,39 @@
+import os
+import sys
+from pathlib import Path
+import urllib.request
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from aissembly_core.parser import parse_program
+from aissembly_core.executor import Executor, load_llm_defs
+
+ROOT = Path(__file__).resolve().parent.parent
+EXAMPLES_DIR = ROOT / "examples"
+LLM_DEFS = ROOT / "llm_functions.json"
+
+
+class DummyResp:
+    def __init__(self, body: str = "{}"):
+        self.body = body.encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return self.body
+
+
+@pytest.mark.parametrize("path", sorted(EXAMPLES_DIR.rglob("*.asl")))
+def test_example_runs(path, monkeypatch):
+    monkeypatch.setattr(urllib.request, "urlopen", lambda req: DummyResp("{}"))
+    src = path.read_text()
+    prog = parse_program(src)
+    exe = Executor(llm_defs=load_llm_defs(str(LLM_DEFS)))
+    env = exe.run(prog)
+    assert isinstance(env, dict)


### PR DESCRIPTION
## Summary
- add missing built-in operations so example programs run
- handle empty dictionary literals in the parser
- run all `.asl` examples as part of the test suite

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5125368b083298bd63f8754103ad5