### PR TITLE
Show streaming responses in real time

### DIFF
--- a/aissembly_core/executor.py
+++ b/aissembly_core/executor.py
@@ -243,7 +243,10 @@ class Executor:
                         if not line:
                             continue
                         chunk = json.loads(line.decode("utf-8"))
-                        text += chunk.get("response", "")
+                        response_text = chunk.get("response", "")
+                        text += response_text
+                        print(response_text, end="", flush=True)
+                    print()
                     return text
                 body = resp.read().decode("utf-8")
                 return json.loads(body)


### PR DESCRIPTION
## Summary
- Display streamed text chunks as they arrive when `stream` parameter is enabled.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a51b4bc0108329a22d95d9412238de