### PR TITLE
Document parser options and add internal reparse iterations

### DIFF
--- a/aissembly_core/runtime.py
+++ b/aissembly_core/runtime.py
@@ -5,7 +5,7 @@ import argparse
 import json
 from typing import Dict
 
-from .parser import parse_program
+from .parser import parse_program, ParserOptions
 from .executor import Executor, load_llm_defs
 
 
@@ -25,9 +25,8 @@ def main(argv: list[str] | None = None) -> None:
     with open(args.program, "r", encoding="utf-8") as f:
         source = f.read()
 
-    prog = None
-    for _ in range(max(args.reparse_iterations, 1)):
-        prog = parse_program(source)
+    options = ParserOptions(reparse_iterations=args.reparse_iterations)
+    prog = parse_program(source, options=options)
 
     llm_defs: Dict[str, Dict] | None = None
     if args.llm:

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -9,9 +9,10 @@ Aissembly minimal language.
 python -m aissembly_core.runtime path/to/program.asl --llm llm_functions.json --reparse-iterations 2
 ```
 
-The optional `--llm` flag loads LLM function specifications in JSON format.  The
-`--reparse-iterations` flag controls how many times the source is reparsed line
-by line before execution (default is `1`).
+The optional `--llm` flag loads LLM function specifications in JSON format.
+`--reparse-iterations` forwards to ``ParserOptions.reparse_iterations`` and
+controls how many times the source is reparsed line by line before execution
+(default is `1`).
 
 ## Example
 
@@ -37,6 +38,22 @@ Executing this program produces the environment:
 
 `parse_program` incrementally reparses each line of the source. This enables
 interactive sessions to handle single-line edits or streamed input.
+
+## Parser Options
+
+The :class:`aissembly_core.parser.ParserOptions` dataclass configures parser
+behaviour:
+
+- ``reparse_iterations`` – how many times to parse the entire source before
+  optimisation.
+- ``accuracy_opt_passes`` – count of accuracy optimisation passes.
+- ``decomposition_opt_passes`` – number of decomposition optimisation passes.
+- ``integration_opt_passes`` – number of integration optimisation passes.
+- ``loop_to_operation_opt_passes`` – convert loops into operations.
+- ``operation_to_loop_opt_passes`` – convert operations into loops.
+- ``condition_to_operation_opt_passes`` – convert conditions into operations.
+
+These optimisation passes are placeholders for future LLM-driven transforms.
 
 ### Python API Example
 

--- a/tests/test_parser_options.py
+++ b/tests/test_parser_options.py
@@ -14,6 +14,7 @@ let steps = while(test=lt(acc, 3), init=0) -> add(acc, 1)
 
 def test_parser_options_acceptance():
     opts = ParserOptions(
+        reparse_iterations=2,
         accuracy_opt_passes=1,
         decomposition_opt_passes=1,
         integration_opt_passes=1,


### PR DESCRIPTION
## Summary
- document each parser optimisation option and add `reparse_iterations`
- allow parser to reparse source internally before executing optimisation passes
- forward CLI `--reparse-iterations` to new parser option and document usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a51c1b353483299f838e160f363fb8